### PR TITLE
Remove obselete usages of Numsharp.

### DIFF
--- a/docs/components/Constant.md
+++ b/docs/components/Constant.md
@@ -24,7 +24,7 @@ var c4 = tf.constant("Big Tree"); // string
 
 Initialize a constant through ndarray:
 
-TF.NET works very well with `NumSharp`'s `NDArray`.  You can create a tensor from .NET primitive data type and NDArray as well. An `ndarray` is a (usually fixed-size) multidimensional container of items of the same type and size. The number of dimensions and items in an array is defined by its `shape`, which is a tuple of N non-negative integers that specify the sizes of each dimension.
+TF.NET used to work with `Numsharp`, which is a C# binding of `Numpy`. In the current version, however, TF.NET put the `NDArray` and many other numpy features inside the TF.NET, you can import `using Tensorflow.NumPy` to create an `NDArray`.
 
 ```csharp
 // dtype=int, shape=(2, 3)

--- a/docs/components/ConvolutionNeuralNetwork.md
+++ b/docs/components/ConvolutionNeuralNetwork.md
@@ -20,7 +20,7 @@ Get started with the implementation:
 
    ```csharp
    using System;
-   using NumSharp;
+   using Tensorflow.NumPy;
    using Tensorflow;
    using TensorFlowNET.Examples.Utility;
    using static Tensorflow.Python;

--- a/docs/components/NeuralNetwork.md
+++ b/docs/components/NeuralNetwork.md
@@ -20,7 +20,7 @@ Get started with the implementation step by step:
 
    ```csharp
    using System;
-   using NumSharp;
+   using Tensorflow.NumPy;
    using Tensorflow;
    using TensorFlowNET.Examples.Utility;
    using static Tensorflow.Python;

--- a/docs/components/tensor.md
+++ b/docs/components/tensor.md
@@ -32,7 +32,7 @@ Console.WriteLine($"t1: {t1}, t2: {t2}, t3: {t3}");
 
 ## Data Structure of Tensor
 
-TF uses column major order. If we use NumSharp to generate a 2 x 3 matrix, if we access the data from 0 to 5 in order, we won't get a number of 1-6, but we get the order of 1, 4, 2, 5, 3, 6. a set of numbers.
+TF uses column major order. If we generate a 2 x 3 matrix (`NDArray`), if we access the data from 0 to 5 in order, we won't get a number of 1-6, but we get the order of 1, 4, 2, 5, 3, 6. a set of numbers.
 
 ```csharp
 // Generate a matrix:[[1, 2, 3], [4, 5, 6]]

--- a/docs/essentials/introduction.md
+++ b/docs/essentials/introduction.md
@@ -32,7 +32,7 @@ Import TF.NET and Keras API in your project.
 using static Tensorflow.Binding;
 using static Tensorflow.KerasApi;
 using Tensorflow;
-using NumSharp;
+using Tensorflow.NumPy;
 ```
 
 Linear Regression in `Eager` mode:

--- a/docs/tutorials/ImageRecognition.md
+++ b/docs/tutorials/ImageRecognition.md
@@ -1,6 +1,6 @@
 # Image Recognition
 
-An example for using the [TensorFlow.NET](https://github.com/SciSharp/TensorFlow.NET) and [NumSharp](https://github.com/SciSharp/NumSharp) for image recognition, it will use a pre-trained inception model to predict a image which outputs the categories sorted by probability. The original paper is [here](https://arxiv.org/pdf/1512.00567.pdf). The Inception architecture of GoogLeNet was designed to perform well even under strict constraints on memory and computational budget. The computational cost of Inception is also much lower than other performing successors. This has made it feasible to utilize Inception networks in big-data scenarios, where huge amount of data needed to be processed at reasonable cost or scenarios where memory or computational capacity is inherently limited, for example in mobile vision settings.
+An example for using the [TensorFlow.NET](https://github.com/SciSharp/TensorFlow.NET) for image recognition, it will use a pre-trained inception model to predict a image which outputs the categories sorted by probability. The original paper is [here](https://arxiv.org/pdf/1512.00567.pdf). The Inception architecture of GoogLeNet was designed to perform well even under strict constraints on memory and computational budget. The computational cost of Inception is also much lower than other performing successors. This has made it feasible to utilize Inception networks in big-data scenarios, where huge amount of data needed to be processed at reasonable cost or scenarios where memory or computational capacity is inherently limited, for example in mobile vision settings.
 
 The GoogLeNet architecture conforms to below design principles:
 
@@ -68,7 +68,7 @@ private NDArray ReadTensorFromImageFile(string file_name,
 
 ### 3. Load pre-trained model and predict
 
-Load the pre-trained inception model which is saved as Google's protobuf file format. Construct a new graph then set input and output operations in a new session. After run the session, you will get a numpy-like ndarray which is provided by NumSharp. With NumSharp, you can easily perform various operations on multiple dimensional arrays in the .NET environment.
+Load the pre-trained inception model which is saved as Google's protobuf file format. Construct a new graph then set input and output operations in a new session. After run the session, you will get a numpy-like ndarray. Thus, you can easily perform various operations on multiple dimensional arrays in the .NET environment.
 
 ```csharp
 public void Run()

--- a/docs/zh-cn/essentials/introduction.md
+++ b/docs/zh-cn/essentials/introduction.md
@@ -32,7 +32,7 @@
 using static Tensorflow.Binding;
 using static Tensorflow.KerasApi;
 using Tensorflow;
-using NumSharp;
+using Tensorflow.NumPy;
 ```
 
 线性回归（Linear Regression）：
@@ -137,9 +137,8 @@ model.fit(x_train[new Slice(0, 1000)], y_train[new Slice(0, 1000)],
 #r "nuget: TensorFlow.Net"
 #r "nuget: TensorFlow.Keras"
 #r "nuget: SciSharp.TensorFlow.Redist"
-#r "nuget: NumSharp"
 
-open NumSharp
+open Tensorflow.NumPy;
 open Tensorflow
 open type Tensorflow.Binding
 open type Tensorflow.KerasApi


### PR DESCRIPTION
`Numsharp` is no longer used as default dependency of `TF.NET`, update the docs.